### PR TITLE
Harden Pi Pico firmware for unattended operation

### DIFF
--- a/devices/pi-pico/main.py
+++ b/devices/pi-pico/main.py
@@ -11,8 +11,26 @@ import urequests
 WIFI_FILE = "wifi.json"
 DEVICE_FILE = "device.json"
 
+BOOT_WIFI_ATTEMPTS = 2               # quick attempts before falling back to the portal
+AP_RETRY_SAVED_MS = 5 * 60 * 1000    # reboot out of the portal to retry saved creds
+AP_CLIENT_IDLE_MS = 2 * 60 * 1000    # don't reboot the portal while someone is using it
+TAP_DEBOUNCE_MS = 5000
+
 piezo = machine.PWM(machine.Pin(8))
 wlan = network.WLAN(network.STA_IF)
+
+wdt = None  # started once device config is loaded; None on unconfigured devices
+
+def feed():
+    if wdt:
+        wdt.feed()
+
+def sleep_fed(seconds):
+    # Sleep without starving the watchdog (RP2040 WDT max is ~8.3s).
+    end = time.ticks_add(time.ticks_ms(), int(seconds * 1000))
+    while time.ticks_diff(end, time.ticks_ms()) > 0:
+        feed()
+        time.sleep(0.1)
 
 def buzz_on():
     piezo.freq(800)
@@ -42,12 +60,13 @@ def post_with_retry(url, payload, headers, retries=1, delay_s=0.5):
     last_exc = None
     for attempt in range(retries + 1):
         try:
+            feed()
             r = urequests.post(url, data=payload, headers=headers)
             return r, None
         except Exception as e:
             last_exc = e
             if attempt < retries:
-                time.sleep(delay_s)
+                sleep_fed(delay_s)
     return None, last_exc
 
 def read_wifi_config():
@@ -57,7 +76,7 @@ def read_wifi_config():
             print("Successfuly loaded creds", creds["ssid"])
 
             return creds["ssid"], creds["password"]
-    except:
+    except (OSError, ValueError, KeyError):
         return None, None
 
 def read_device_config():
@@ -67,7 +86,7 @@ def read_device_config():
             print("Successfuly loaded device creds for ", creds["device_id"])
 
             return creds["device_id"], creds["lambda_url"], creds["lambda_secret"]
-    except:
+    except (OSError, ValueError, KeyError):
         return None, None, None
 
 def url_decode(s):
@@ -90,12 +109,25 @@ def connect_wifi(ssid, password):
     wlan.connect(ssid, password)
 
     for _ in range(20):  # wait up to 10 seconds
+        feed()
         if wlan.isconnected():
             print("Connected to Wi-Fi:", ssid)
             print("IP:", wlan.ifconfig()[0])
             return True
         time.sleep(0.5)
     print("Failed to connect.")
+    return False
+
+def connect_wifi_with_retry(ssid, password, attempts=BOOT_WIFI_ATTEMPTS):
+    # A couple of quick attempts, then fall back to the portal. The portal
+    # reboots to retry saved creds periodically, so a router that's slow to
+    # come back after a power outage still recovers on a later cycle —
+    # without making a moved device wait to be reconfigured.
+    for attempt in range(attempts):
+        if connect_wifi(ssid, password):
+            return True
+        if attempt < attempts - 1:
+            sleep_fed(2)
     return False
 
 def ensure_wifi(ssid, password, failure_times, retry_delay_s=2):
@@ -112,7 +144,7 @@ def ensure_wifi(ssid, password, failure_times, retry_delay_s=2):
     if len(failure_times) >= 3:
         print("Too many Wi-Fi failures. Starting captive portal.")
         return "ap"
-    time.sleep(retry_delay_s)
+    sleep_fed(retry_delay_s)
     return False
 
 def start_ap_mode():
@@ -143,7 +175,7 @@ def init_nfc():
     pn532.SAM_configuration()
     return pn532
 
-def serve_wifi_form(pn532=None):
+def serve_wifi_form(pn532=None, retry_saved_creds=False):
     html = """\
 HTTP/1.1 200 OK
 
@@ -166,7 +198,16 @@ HTTP/1.1 200 OK
     s.listen(1)
     s.settimeout(0.5)
 
+    started = time.ticks_ms()
+    last_client_ms = None
     while True:
+        feed()
+        if retry_saved_creds and time.ticks_diff(time.ticks_ms(), started) > AP_RETRY_SAVED_MS:
+            portal_idle = (last_client_ms is None or
+                    time.ticks_diff(time.ticks_ms(), last_client_ms) > AP_CLIENT_IDLE_MS)
+            if portal_idle:
+                print("No new credentials. Rebooting to retry saved Wi-Fi.")
+                reset()
         try:
             cl, addr = s.accept()
         except OSError:
@@ -175,103 +216,134 @@ HTTP/1.1 200 OK
                 if uid:
                     print("NFC tap while offline. Buzzing error.")
                     buzz_error_wifi()
-                    time.sleep(2)
+                    sleep_fed(2)
             continue
 
-        request = cl.recv(1024).decode()
-        print("Request:", request)
+        last_client_ms = time.ticks_ms()
+        try:
+            request = cl.recv(1024).decode()
+            print("Request:", request)
 
-        if "ssid=" in request:
-            try:
+            if "ssid=" in request:
                 params = request.split(' ', 2)[1].split('?', 1)[-1].split('&')
                 param_dict = {kv.split('=')[0]: url_decode(kv.split('=')[1]) for kv in params}
                 ssid = param_dict.get("ssid", "")
                 password = param_dict.get("password", "")
-                print("Saving Wi-Fi credentials.")
-                save_wifi_config(ssid, password)
-                cl.send("HTTP/1.1 200 OK\r\n\r\nSaved. Rebooting...")
+                if ssid:
+                    print("Saving Wi-Fi credentials.")
+                    save_wifi_config(ssid, password)
+                    cl.send("HTTP/1.1 200 OK\r\n\r\nSaved. Rebooting...")
+                    cl.close()
+                    sleep_fed(2)
+                    reset()
+
+            cl.send(html)
+        except Exception as e:
+            print("Failed to handle client:", e)
+        finally:
+            try:
                 cl.close()
-                time.sleep(2)
-                reset()
-                return
-            except Exception as e:
-                print("Failed to parse:", e)
+            except OSError:
+                pass
 
-        cl.send(html)
-        cl.close()
+def tap_loop(pn532, ssid, password, device_id, lambda_url, lambda_secret):
+    wifi_failure_times = []
+    last_uid = None
+    last_seen_ms = 0
+    print("Waiting for NFC card...")
+    while True:
+        feed()
+        wifi_status = ensure_wifi(ssid, password, wifi_failure_times)
+        if wifi_status == "ap":
+            start_ap_mode()
+            serve_wifi_form(pn532, retry_saved_creds=True)
+            return
+        if not wifi_status:
+            continue
 
-device_id, lambda_url, lambda_secret = read_device_config()
+        uid = pn532.read_passive_target(timeout=1)
+        if uid is None:
+            continue
 
-if device_id and lambda_url and lambda_secret:
+        uid_str = "".join(["%02X" % b for b in uid])
+        now = time.ticks_ms()
+        if uid_str == last_uid and time.ticks_diff(now, last_seen_ms) < TAP_DEBOUNCE_MS:
+            # Same card still on the reader; keep the debounce window open.
+            last_seen_ms = now
+            continue
+        last_uid = uid_str
+        last_seen_ms = now
+
+        print("Card detected! UID:", uid_str)
+
+        buzz_on()
+
+        try:
+            payload = json.dumps({
+                "deviceid": device_id,
+                "cardID": uid_str
+            })
+            headers = {
+                "Content-Type": "application/json",
+                "x-internal": lambda_secret
+            }
+            lambda_endpoint = lambda_url + "/tap"
+            r, err = post_with_retry(lambda_endpoint, payload, headers, retries=1, delay_s=0.5)
+            if err:
+                print("Request failed after retry:", err)
+                buzz_error_lambda()
+            else:
+                try:
+                    print("Response status:", r.status_code)
+                    print("Response text:", r.text)
+                    if r.status_code < 200 or r.status_code >= 300:
+                        print("Lambda error status. Buzzing error.")
+                        buzz_error_lambda()
+                finally:
+                    r.close()
+        except Exception as e:
+            print("Request failed:", e)
+            buzz_error_lambda()
+
+def run():
+    global wdt
+
+    device_id, lambda_url, lambda_secret = read_device_config()
+    if not (device_id and lambda_url and lambda_secret):
+        print("No device configuration found.")
+        return
+
     print("Using device ID:", device_id)
 
+    # Watchdog: reboots the device if anything hangs (e.g. a stalled HTTP
+    # request — urequests has no timeout). Not started on unconfigured
+    # devices so they stay at the REPL for setup.
+    wdt = machine.WDT(timeout=8000)
+
     ssid, password = read_wifi_config()
-
-    if ssid and password:
-        buzz_on();
-        if connect_wifi(ssid, password):
-
-            pn532 = init_nfc()
-            wifi_failure_times = []
-            never_ran = True
-            while True:
-                wifi_status = ensure_wifi(ssid, password, wifi_failure_times)
-                if wifi_status == "ap":
-                    start_ap_mode()
-                    serve_wifi_form(pn532)
-                    break
-                if not wifi_status:
-                    continue
-                if never_ran:
-                    print("Waiting for NFC card...")
-                    never_ran = False
-                uid = pn532.read_passive_target(timeout=1)
-                if uid is None:
-                    continue
-
-                uid_str = "".join(["%02X" % b for b in uid])
-                print("Card detected! UID:", uid_str)
-                
-                buzz_on();
-
-                try:
-                    payload = json.dumps({
-                        "deviceid": device_id,
-                        "cardID": uid_str
-                    })
-                    headers = {
-                        "Content-Type": "application/json",
-                        "x-internal": lambda_secret
-                    }
-                    lambda_endpoint = lambda_url + "/tap"
-                    r, err = post_with_retry(lambda_endpoint, payload, headers, retries=1, delay_s=0.5)
-                    if err:
-                        print("Request failed after retry:", err)
-                        buzz_error_lambda()
-                    else:
-                        print("Response status:", r.status_code)
-                        print("Response text:", r.text)
-                        if r.status_code < 200 or r.status_code >= 300:
-                            print("Lambda error status. Buzzing error.")
-                            buzz_error_lambda()
-                        r.close()
-                except Exception as e:
-                    print("Request failed:", e)
-                    buzz_error_lambda()
-
-                time.sleep(5)
-                
-        else:
-            print("Failed to connect. Starting captive portal.")
-            start_ap_mode()
-            pn532 = init_nfc()
-            serve_wifi_form(pn532)
-    else:
+    if not (ssid and password):
         print("No credentials. Starting captive portal.")
         start_ap_mode()
         pn532 = init_nfc()
         serve_wifi_form(pn532)
+        return
 
-else :
-    print("No device configuration found.")
+    buzz_on()
+    if not connect_wifi_with_retry(ssid, password):
+        print("Failed to connect. Starting captive portal.")
+        start_ap_mode()
+        pn532 = init_nfc()
+        serve_wifi_form(pn532, retry_saved_creds=True)
+        return
+
+    pn532 = init_nfc()
+    tap_loop(pn532, ssid, password, device_id, lambda_url, lambda_secret)
+
 # MAIN LOGIC
+try:
+    run()
+except Exception as e:
+    print("Fatal error:", e)
+    buzz_error_lambda()
+    sleep_fed(3)
+    reset()


### PR DESCRIPTION
## What changed

Reliability rework of `devices/pi-pico/main.py` so the device survives long unattended stretches on a wall instead of needing power cycles:

- **Crash recovery** — all logic now lives in `run()` under a top-level handler that logs, buzzes, and `machine.reset()`s on any uncaught exception (the PN532 driver occasionally raises `RuntimeError` on SPI glitches, which previously left the device dead at the REPL). The captive portal also wraps per-client handling in try/except with a guaranteed socket close.
- **Hardware watchdog** — `machine.WDT(timeout=8000)` guards against hangs, notably `urequests.post` which has no timeout. A `sleep_fed()` helper keeps it fed through long waits. The WDT is *not* started when `device.json` is missing, so fresh boards stay at the REPL for setup.
- **Power-outage / relocation recovery** — boot makes two quick Wi-Fi attempts (~22s) then opens the captive portal, so a device moved to a new network is configurable in under a minute. When the portal was entered with saved credentials, it reboots every 5 minutes to retry them (covering the slow-router-after-outage case) — but skips the reboot if anyone has hit the portal in the last 2 minutes, so setup isn't interrupted.
- **Tap debounce** — the post-tap `time.sleep(5)` is replaced with per-UID debouncing: the same card is ignored while it stays within a refreshing 5s window, but a different card can tap immediately.
- **Smaller fixes** — HTTP responses closed in `try/finally` (MicroPython has very few sockets), bare `except:` clauses narrowed to `(OSError, ValueError, KeyError)`.

## Reviewer notes

- Once the WDT starts it can't be stopped: Ctrl-C into the REPL on a *configured* board reboots it ~8s later. For bench work, temporarily rename `device.json` (or use `check_connectivity.py`, which never starts the WDT).
- Wrong-password and router-down are indistinguishable at boot, so both now cycle: ~22s of trying → 5 min portal → retry. Outage recovery worst case is roughly 5–6 minutes after the router returns.
- Syntax-checked with `py_compile`; not yet run on hardware — worth a bench pass with `check_connectivity.py` and a real tap before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)