### PR TITLE
Fix Spotify token lifecycle, bump Lambda runtime to Node 22, tolerant proxy parsing

### DIFF
--- a/apps/web/app/api/add-card/route.ts
+++ b/apps/web/app/api/add-card/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { upstreamJson } from '@/lib/upstream';
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -22,6 +23,6 @@ export async function POST(req: NextRequest) {
     body: JSON.stringify({ userid, cardID, spotifyURL }),
   });
 
-  const data = await lambdaRes.json();
+  const data = await upstreamJson(lambdaRes);
   return NextResponse.json(data, { status: lambdaRes.status });
 }

--- a/apps/web/app/api/add-device/route.ts
+++ b/apps/web/app/api/add-device/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { upstreamJson } from '@/lib/upstream';
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -22,6 +23,6 @@ export async function POST(req: NextRequest) {
     body: JSON.stringify({ userid, deviceid }),
   });
 
-  const data = await lambdaRes.json();
+  const data = await upstreamJson(lambdaRes);
   return NextResponse.json(data, { status: lambdaRes.status });
 }

--- a/apps/web/app/api/delete-card/route.ts
+++ b/apps/web/app/api/delete-card/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { upstreamJson } from '@/lib/upstream';
 
 export async function DELETE(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -22,6 +23,6 @@ export async function DELETE(req: NextRequest) {
     body: JSON.stringify({ userid, cardID }),
   });
 
-  const data = await lambdaRes.json();
+  const data = await upstreamJson(lambdaRes);
   return NextResponse.json(data, { status: lambdaRes.status });
 }

--- a/apps/web/app/api/get-cards/route.ts
+++ b/apps/web/app/api/get-cards/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { upstreamJson } from '@/lib/upstream';
 
 // This API route proxies to your Lambda endpoint
 export async function GET() {
@@ -20,11 +21,10 @@ export async function GET() {
     },
   });
 
+  const response = await upstreamJson(lambdaRes);
   if (!lambdaRes.ok) {
-    return NextResponse.json({ error: 'Failed to fetch cards' }, { status: 500 });
+    return NextResponse.json(response, { status: lambdaRes.status });
   }
-
-  const response = await lambdaRes.json();
 
   const cards = response.cards || [];
   const lastCard = response.lastCard || null;

--- a/apps/web/app/api/get-players/route.ts
+++ b/apps/web/app/api/get-players/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { upstreamJson } from '@/lib/upstream';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -18,6 +19,6 @@ export async function GET() {
     },
   });
 
-  const data = await res.json();
+  const data = await upstreamJson(res);
   return NextResponse.json(data, { status: res.status });
 }

--- a/apps/web/app/api/set-player/route.ts
+++ b/apps/web/app/api/set-player/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { upstreamJson } from '@/lib/upstream';
 
 export async function POST(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -25,6 +26,6 @@ export async function POST(req: NextRequest) {
     body: JSON.stringify({ userid, spotifyPlayerId, spotifyPlayerName }),
   });
 
-  const data = await res.json();
+  const data = await upstreamJson(res);
   return NextResponse.json(data, { status: res.status });
 }

--- a/apps/web/lib/upstream.ts
+++ b/apps/web/lib/upstream.ts
@@ -1,0 +1,12 @@
+/**
+ * Parse a Lambda response body that may not be JSON — the Lambdas return
+ * plain text for some errors (e.g. "Forbidden" on 403).
+ */
+export async function upstreamJson(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text || `Upstream error (${res.status})` };
+  }
+}

--- a/services/aws/lambdas/addCard/index.js
+++ b/services/aws/lambdas/addCard/index.js
@@ -1,6 +1,5 @@
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { DynamoDBDocumentClient, PutCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
-const fetch = require("node-fetch");
 
 const CARDS_TABLE = process.env.CARDS_TABLE;
 const USERS_TABLE = process.env.USERS_TABLE;

--- a/services/aws/lambdas/addCard/package.json
+++ b/services/aws/lambdas/addCard/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "addcard",
-  "version": "1.0.0",
-  "description": "Lambda for addcard",
-  "main": "index.js",
-  "dependencies": {
-    "node-fetch": "^2.6.7"
-  }
-}

--- a/services/aws/lambdas/getPlayers/index.js
+++ b/services/aws/lambdas/getPlayers/index.js
@@ -1,6 +1,5 @@
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
-const fetch = require("node-fetch");
 
 const USERS_TABLE = process.env.USERS_TABLE;
 

--- a/services/aws/lambdas/getPlayers/package.json
+++ b/services/aws/lambdas/getPlayers/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "getplayers",
-  "version": "1.0.0",
-  "description": "Lambda for getplayers",
-  "main": "index.js",
-  "dependencies": {
-    "node-fetch": "^2.6.7"
-  }
-}

--- a/services/aws/lambdas/tapCard/index.js
+++ b/services/aws/lambdas/tapCard/index.js
@@ -1,11 +1,15 @@
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
-const fetch = require("node-fetch");
 
 const DEVICES_TABLE = process.env.DEVICES_TABLE;
 const CARDS_TABLE = process.env.CARDS_TABLE;
 const USERS_TABLE = process.env.USERS_TABLE;
-const PLAYER_ID= "92aea6c4165c29ecb355eb798c86571e82ef1fe0";
+
+function spotifyError(message, status) {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+}
 
 /**
  * Resolve the best available Spotify device for playback.
@@ -14,8 +18,8 @@ const PLAYER_ID= "92aea6c4165c29ecb355eb798c86571e82ef1fe0";
  *   2. Match by saved device ID (in case it's still valid)
  *   3. Fall back to whichever device is currently active
  *   4. Fall back to the first available device
- *   5. Fall back to the hardcoded PLAYER_ID constant
- * Returns { deviceId, deviceName, source } or null if no devices at all.
+ *   5. Fall back to the saved device ID even if unlisted (it may be asleep)
+ * Returns { deviceId, deviceName, source } or null if there is nothing to try.
  */
 async function resolveDevice(accessToken, user) {
   let devices = [];
@@ -23,12 +27,16 @@ async function resolveDevice(accessToken, user) {
     const resp = await fetch('https://api.spotify.com/v1/me/player/devices', {
       headers: { 'Authorization': `Bearer ${accessToken}` }
     });
+    if (resp.status === 401) {
+      throw spotifyError('Spotify auth failed while listing devices', 401);
+    }
     if (resp.ok) {
       const data = await resp.json();
       devices = data.devices || [];
     }
   } catch (err) {
-    // If device fetch fails, fall through to hardcoded fallback
+    if (err.status === 401) throw err;
+    // If device fetch fails otherwise, fall through to the saved fallback
   }
 
   if (devices.length > 0) {
@@ -52,11 +60,11 @@ async function resolveDevice(accessToken, user) {
     return { deviceId: devices[0].id, deviceName: devices[0].name, source: 'first_available' };
   }
 
-  // 5. Last resort: hardcoded fallback
+  // 5. Saved device even though Spotify didn't list it — transfer may wake it
   if (user.playerid) {
     return { deviceId: user.playerid, deviceName: user.playerName || 'unknown', source: 'saved_fallback' };
   }
-  return { deviceId: PLAYER_ID, deviceName: 'hardcoded_default', source: 'hardcoded_fallback' };
+  return null;
 }
 
 /**
@@ -76,8 +84,42 @@ async function transferPlayback(accessToken, deviceId) {
   // 204 = success, 404 = no active device (ok to ignore)
   if (!resp.ok && resp.status !== 404) {
     const errText = await resp.text();
-    throw new Error(`Transfer playback failed: ${resp.status} ${errText}`);
+    throw spotifyError(`Transfer playback failed: ${resp.status} ${errText}`, resp.status);
   }
+}
+
+/**
+ * Refresh the Spotify access token and persist it. Spotify occasionally
+ * rotates the refresh token in the response; store the new one or the
+ * account eventually becomes unrecoverable.
+ */
+async function refreshSpotifyToken(ddbDocClient, userid, refreshToken) {
+  const params = new URLSearchParams();
+  params.append('grant_type', 'refresh_token');
+  params.append('refresh_token', refreshToken);
+  params.append('client_id', process.env.SPOTIFY_CLIENT_ID);
+  params.append('client_secret', process.env.SPOTIFY_CLIENT_SECRET);
+  const resp = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params
+  });
+  if (!resp.ok) throw new Error('Failed to refresh Spotify token');
+  const tokenData = await resp.json();
+  const accessToken = tokenData.access_token;
+  const expiresAt = Math.floor(Date.now() / 1000) + tokenData.expires_in;
+  const newRefreshToken = tokenData.refresh_token || refreshToken;
+  await ddbDocClient.send(new UpdateCommand({
+    TableName: USERS_TABLE,
+    Key: { userid },
+    UpdateExpression: 'SET accessToken = :at, expiresAt = :ea, refreshToken = :rt',
+    ExpressionAttributeValues: {
+      ':at': accessToken,
+      ':ea': expiresAt,
+      ':rt': newRefreshToken
+    }
+  }));
+  return { accessToken, refreshToken: newRefreshToken, expiresAt };
 }
 
 async function recordUserError(ddbDocClient, userid, message) {
@@ -148,15 +190,12 @@ exports.handler = async (event) => {
       Key: { userid, cardID }
     }));
     card = cardRes.Item;
-    // if (!card) {
-      // return { statusCode: 404, body: JSON.stringify({ error: "Card not found" }) };
-    // }
   } catch (err) {
     const message = err.message || 'Failed to load card';
     await recordUserError(ddbDocClient, userid, message);
     return { statusCode: 500, body: JSON.stringify({ error: message }) };
   }
-  // 3. Lookup user record and log it
+  // 3. Lookup user record
   let user;
   try {
     const userRes = await ddbDocClient.send(new GetCommand({
@@ -190,98 +229,95 @@ exports.handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: message }) };
   }
 
-  // 5. Spotify API: get accessToken, refresh if needed, fetch devices
+  if (!card) {
+    return { statusCode: 200, body: JSON.stringify({ message: "Tap recorded- new card" }) };
+  }
+
+  // 5. Spotify API: get accessToken, refresh proactively if we know it expired.
+  // A stale or missing expiresAt is covered by the retry-on-401 below.
   let accessToken = user.accessToken;
   let refreshToken = user.refreshToken;
-  let expiresAt = user.expiresAt;
+  const expiresAt = user.expiresAt;
   const now = Math.floor(Date.now() / 1000);
 
-  if (card){
-    // If token expired, refresh
-    if (expiresAt && now >= expiresAt && refreshToken) {
-      try {
-        const params = new URLSearchParams();
-        params.append('grant_type', 'refresh_token');
-        params.append('refresh_token', refreshToken);
-        params.append('client_id', process.env.SPOTIFY_CLIENT_ID);
-        params.append('client_secret', process.env.SPOTIFY_CLIENT_SECRET);
-        const resp = await fetch('https://accounts.spotify.com/api/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: params
-        });
-        if (!resp.ok) throw new Error('Failed to refresh Spotify token');
-        const tokenData = await resp.json();
-        accessToken = tokenData.access_token;
-        expiresAt = now + tokenData.expires_in;
-        // Optionally update user record with new token
-        await ddbDocClient.send(new UpdateCommand({
-          TableName: USERS_TABLE,
-          Key: { userid },
-          UpdateExpression: 'SET accessToken = :at, expiresAt = :ea',
-          ExpressionAttributeValues: {
-            ':at': accessToken,
-            ':ea': expiresAt
-          }
-        }));
-      } catch (err) {
-        const message = 'Spotify token refresh failed: ' + err.message;
-        await recordUserError(ddbDocClient, userid, message);
-        return { statusCode: 500, body: JSON.stringify({ error: message }) };
-      }
+  if (expiresAt && now >= expiresAt && refreshToken) {
+    try {
+      const refreshed = await refreshSpotifyToken(ddbDocClient, userid, refreshToken);
+      accessToken = refreshed.accessToken;
+      refreshToken = refreshed.refreshToken;
+    } catch (err) {
+      const message = 'Spotify token refresh failed: ' + err.message;
+      await recordUserError(ddbDocClient, userid, message);
+      return { statusCode: 500, body: JSON.stringify({ error: message }) };
     }
-
-    // 6. Resolve device, transfer playback, then play
-    let playStatus = 'not attempted';
-    let deviceSource = 'none';
-    if (accessToken && (card.spotifyURL || card.spotifyUrl)) {
-      try {
-        // Resolve the best available device
-        const device = await resolveDevice(accessToken, user);
-        deviceSource = device.source;
-
-        // Update saved playerid if we resolved by name and the ID changed
-        if (device.source === 'name_match' && device.deviceId !== user.playerid) {
-          try {
-            await ddbDocClient.send(new UpdateCommand({
-              TableName: USERS_TABLE,
-              Key: { userid },
-              UpdateExpression: 'SET playerid = :pid',
-              ExpressionAttributeValues: { ':pid': device.deviceId }
-            }));
-          } catch (_) { /* non-critical, continue */ }
-        }
-
-        // Transfer playback to wake up the device
-        await transferPlayback(accessToken, device.deviceId);
-
-        // Play the track
-        const spotifyURL = card.spotifyURL || card.spotifyUrl;
-        const uri = extractSpotifyTrackId(spotifyURL);
-        const playResp = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${device.deviceId}`,
-          {
-            method: 'PUT',
-            headers: {
-              'Authorization': `Bearer ${accessToken}`,
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({ uris: [`spotify:track:${uri}`] })
-          }
-        );
-        if (!playResp.ok) {
-          const errText = await playResp.text();
-          throw new Error(`Spotify play failed (device: ${device.deviceName}, source: ${device.source}): ${playResp.status} ${errText}`);
-        }
-        playStatus = 'success';
-      } catch (err) {
-        const message = 'Spotify play failed: ' + err.message;
-        await recordUserError(ddbDocClient, userid, message);
-        return { statusCode: 500, body: JSON.stringify({ error: message }) };
-      }
-    }
-
-    return { statusCode: 200, body: JSON.stringify({ message: "Tap recorded and song played", spotifyURL: card.spotifyURL || card.spotifyUrl, playStatus, deviceSource }) };
   }
-  return { statusCode: 200, body: JSON.stringify({ message: "Tap recorded- new card" }) };
 
+  // 6. Resolve device, transfer playback, then play
+  let playStatus = 'not attempted';
+  let deviceSource = 'none';
+  const spotifyURL = card.spotifyURL || card.spotifyUrl;
+  if (accessToken && spotifyURL) {
+    const playOnce = async (token) => {
+      const device = await resolveDevice(token, user);
+      if (!device) {
+        throw spotifyError('No Spotify device available — open Spotify on a player and set it in the dashboard', 404);
+      }
+      deviceSource = device.source;
+
+      // Update saved playerid if we resolved by name and the ID changed
+      if (device.source === 'name_match' && device.deviceId !== user.playerid) {
+        try {
+          await ddbDocClient.send(new UpdateCommand({
+            TableName: USERS_TABLE,
+            Key: { userid },
+            UpdateExpression: 'SET playerid = :pid',
+            ExpressionAttributeValues: { ':pid': device.deviceId }
+          }));
+        } catch (_) { /* non-critical, continue */ }
+      }
+
+      // Transfer playback to wake up the device
+      await transferPlayback(token, device.deviceId);
+
+      // Play the track
+      const uri = extractSpotifyTrackId(spotifyURL);
+      const playResp = await fetch(`https://api.spotify.com/v1/me/player/play?device_id=${device.deviceId}`,
+        {
+          method: 'PUT',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ uris: [`spotify:track:${uri}`] })
+        }
+      );
+      if (!playResp.ok) {
+        const errText = await playResp.text();
+        throw spotifyError(`Spotify play failed (device: ${device.deviceName}, source: ${device.source}): ${playResp.status} ${errText}`, playResp.status);
+      }
+    };
+
+    try {
+      try {
+        await playOnce(accessToken);
+      } catch (err) {
+        // The stored token can be stale even when expiresAt says otherwise —
+        // refresh once and retry.
+        if (err.status === 401 && refreshToken) {
+          const refreshed = await refreshSpotifyToken(ddbDocClient, userid, refreshToken);
+          accessToken = refreshed.accessToken;
+          await playOnce(accessToken);
+        } else {
+          throw err;
+        }
+      }
+      playStatus = 'success';
+    } catch (err) {
+      const message = 'Spotify play failed: ' + err.message;
+      await recordUserError(ddbDocClient, userid, message);
+      return { statusCode: 500, body: JSON.stringify({ error: message }) };
+    }
+  }
+
+  return { statusCode: 200, body: JSON.stringify({ message: "Tap recorded and song played", spotifyURL, playStatus, deviceSource }) };
 };

--- a/services/aws/lambdas/tapCard/package.json
+++ b/services/aws/lambdas/tapCard/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "tapcard",
-  "version": "1.0.0",
-  "description": "Lambda for tapcard",
-  "main": "index.js",
-  "dependencies": {
-    "node-fetch": "^2.6.7"
-  }
-}

--- a/services/aws/template.yaml
+++ b/services/aws/template.yaml
@@ -59,7 +59,7 @@ Resources:
     Properties:
       FunctionName: getUserCards
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/getUserCards/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -84,7 +84,7 @@ Resources:
     Properties:
       FunctionName: deleteCard
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/deleteCard/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -109,7 +109,7 @@ Resources:
     Properties:
       FunctionName: registerUser
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/registerUser/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -131,7 +131,7 @@ Resources:
     Properties:
       FunctionName: addDevice
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/addDevice/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -156,7 +156,7 @@ Resources:
     Properties:
       FunctionName: addCard
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/addCard/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -183,7 +183,7 @@ Resources:
     Properties:
       FunctionName: tapCard
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/tapCard/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -213,7 +213,7 @@ Resources:
     Properties:
       FunctionName: getPlayers
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/getPlayers/
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -237,7 +237,7 @@ Resources:
     Properties:
       FunctionName: setPlayer
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       CodeUri: lambdas/setPlayer/
       Policies:
         - AWSLambdaBasicExecutionRole


### PR DESCRIPTION
## What changed

Follow-up to #20 — the correctness fixes from the app review.

**`tapCard` Spotify token lifecycle**
- Persist rotated refresh tokens: Spotify occasionally returns a new `refresh_token` on refresh; the old code dropped it, which eventually bricks the account with no recovery path. A shared `refreshSpotifyToken` helper now stores `accessToken`, `expiresAt`, and `refreshToken` together.
- Retry once on 401: the resolve-device → transfer-playback → play flow retries a single time after a token refresh, covering stale or missing `expiresAt` values. A 401 from the devices listing is now treated as an auth failure instead of being swallowed as "no devices".
- Removed the hardcoded `PLAYER_ID` fallback (a personal device ID baked into source). With no saved player and no live devices, the tap records a clear "No Spotify device available" error, visible in the dashboard's last-error display.

**Lambda runtime**
- All 8 functions bumped from `nodejs18.x` (end-of-life; AWS is progressively blocking updates on it) to `nodejs22.x`.
- Dropped `node-fetch` — `fetch` is global since Node 18 — deleting the three `package.json` files that existed only for it. The Lambdas now have zero npm dependencies.

**Web proxy routes**
- New `lib/upstream.ts` helper parses Lambda responses as text-then-JSON, so plain-text errors like `"Forbidden"` surface as `{ "error": "Forbidden" }` with the real status instead of crashing `res.json()` into a 500. `get-cards` also passes through the upstream status instead of flattening to 500.

## Reviewer notes

- Needs `./deploy.sh` to take effect on the Lambda side. The runtime bump makes this deploy worth watching; after it completes, one end-to-end tap test is recommended.
- Behavior change: users with no saved player and no reachable Spotify device now get an explicit error (error buzz on device, message in dashboard) instead of a confusing 404 against a stranger's device ID.
- Verified with `node --check` on all handlers, `tsc --noEmit`, a full `next build`, and `sam validate --lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)