### PR TITLE
Add Telegram notifications for sign-ins, cards, devices, and unknown taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 ## deploy aws assets with:
 deploy.sh
 
+## telegram notifications (optional):
+- message @BotFather in Telegram, /newbot, copy the bot token
+- open a chat with your new bot and press Start
+- get your numeric chat id from @userinfobot
+- add TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID to .env, then run deploy.sh
+- pings on: sign-in, new user, card added, device claimed, unknown card tapped
+
 # web app
 - cd apps/web
 - npm run dev

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,4 +12,6 @@ sam deploy \
   --parameter-overrides \
     InternalSecret="$INTERNAL_SECRET" \
     SpotifyClientId="$SPOTIFY_CLIENT_ID" \
-    SpotifyClientSecret="$SPOTIFY_CLIENT_SECRET" 
+    SpotifyClientSecret="$SPOTIFY_CLIENT_SECRET" \
+    TelegramBotToken="$TELEGRAM_BOT_TOKEN" \
+    TelegramChatId="$TELEGRAM_CHAT_ID"

--- a/services/aws/lambdas/addCard/index.js
+++ b/services/aws/lambdas/addCard/index.js
@@ -5,6 +5,23 @@ const CARDS_TABLE = process.env.CARDS_TABLE;
 const USERS_TABLE = process.env.USERS_TABLE;
 const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
 const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
+
+// Best-effort Telegram ping; must never fail the main flow.
+async function notify(text) {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text }),
+      signal: AbortSignal.timeout(3000)
+    });
+  } catch (err) {
+    console.error('Telegram notify failed:', err);
+  }
+}
 
 function extractSpotifyTrackId(url) {
   const match = url.match(/spotify\.com\/track\/([a-zA-Z0-9]+)/);
@@ -93,6 +110,8 @@ exports.handler = async (event) => {
       TableName: CARDS_TABLE,
       Item: { userid, cardID, spotifyURL, trackName, artistName }
     }));
+    const trackLabel = trackName ? `${trackName}${artistName ? ' — ' + artistName : ''}` : spotifyURL;
+    await notify(`🎵 ${userid} added a card: ${trackLabel}`);
     return { statusCode: 201, body: JSON.stringify({ message: "Card added", trackName, artistName }) };
   } catch (err) {
     const message = err.message || 'Failed to add card';

--- a/services/aws/lambdas/addDevice/index.js
+++ b/services/aws/lambdas/addDevice/index.js
@@ -3,6 +3,23 @@ const { DynamoDBDocumentClient, UpdateCommand, PutCommand } = require("@aws-sdk/
 
 const USERS_TABLE = process.env.USERS_TABLE;
 const DEVICES_TABLE = process.env.DEVICES_TABLE;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
+
+// Best-effort Telegram ping; must never fail the main flow.
+async function notify(text) {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text }),
+      signal: AbortSignal.timeout(3000)
+    });
+  } catch (err) {
+    console.error('Telegram notify failed:', err);
+  }
+}
 
 if (!DEVICES_TABLE) {
   throw new Error("DEVICES_TABLE environment variable is not set");
@@ -66,6 +83,7 @@ exports.handler = async (event) => {
       TableName: DEVICES_TABLE,
       Item: { deviceid, userid }
     }));
+    await notify(`📟 Device ${deviceid} claimed by ${userid}`);
     return { statusCode: 200, body: JSON.stringify({ message: "Device ID added to user and devices table" }) };
   } catch (err) {
     const message = err.message || 'Failed to add device';

--- a/services/aws/lambdas/registerUser/index.js
+++ b/services/aws/lambdas/registerUser/index.js
@@ -2,6 +2,23 @@ const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand } = require("@aws-sdk/lib-dynamodb");
 
 const USERS_TABLE = process.env.USERS_TABLE;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
+
+// Best-effort Telegram ping; must never fail the main flow.
+async function notify(text) {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text }),
+      signal: AbortSignal.timeout(3000)
+    });
+  } catch (err) {
+    console.error('Telegram notify failed:', err);
+  }
+}
 
 async function recordUserError(ddbDocClient, userid, message) {
   if (!userid) return;
@@ -75,6 +92,7 @@ exports.handler = async (event) => {
         }));
       }
       console.log('User already exists, tokens refreshed:', userid);
+      await notify(`🔑 ${name || userid} signed in`);
       return { statusCode: 200, body: JSON.stringify({ message: 'User already exists' }) };
     }
 
@@ -93,6 +111,7 @@ exports.handler = async (event) => {
     };
     await ddbDocClient.send(new PutCommand(putParams))
     console.log('Inserted new user:', userid);
+    await notify(`👋 New user signed up: ${name || userid} (${userid})`);
     return { statusCode: 201, body: JSON.stringify({ message: 'User created' }) };
   } catch (err) {
     console.error('DynamoDB error:', err);

--- a/services/aws/lambdas/tapCard/index.js
+++ b/services/aws/lambdas/tapCard/index.js
@@ -4,6 +4,23 @@ const { DynamoDBDocumentClient, GetCommand, UpdateCommand } = require("@aws-sdk/
 const DEVICES_TABLE = process.env.DEVICES_TABLE;
 const CARDS_TABLE = process.env.CARDS_TABLE;
 const USERS_TABLE = process.env.USERS_TABLE;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
+
+// Best-effort Telegram ping; must never fail the main flow.
+async function notify(text) {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text }),
+      signal: AbortSignal.timeout(3000)
+    });
+  } catch (err) {
+    console.error('Telegram notify failed:', err);
+  }
+}
 
 function spotifyError(message, status) {
   const err = new Error(message);
@@ -230,6 +247,7 @@ exports.handler = async (event) => {
   }
 
   if (!card) {
+    await notify(`❓ New card ${cardID} tapped on device ${deviceid} — assign it in the dashboard`);
     return { statusCode: 200, body: JSON.stringify({ message: "Tap recorded- new card" }) };
   }
 

--- a/services/aws/template.yaml
+++ b/services/aws/template.yaml
@@ -12,6 +12,13 @@ Parameters:
   SpotifyClientSecret:
     Type: String
     NoEcho: true
+  TelegramBotToken:
+    Type: String
+    NoEcho: true
+    Default: ''
+  TelegramChatId:
+    Type: String
+    Default: ''
 
 Resources:
   UsersTable:
@@ -119,6 +126,8 @@ Resources:
         Variables:
           USERS_TABLE: tappyusers
           INTERNAL_SECRET: !Ref InternalSecret
+          TELEGRAM_BOT_TOKEN: !Ref TelegramBotToken
+          TELEGRAM_CHAT_ID: !Ref TelegramChatId
       Events:
         Api:
           Type: Api
@@ -144,6 +153,8 @@ Resources:
           USERS_TABLE: tappyusers
           DEVICES_TABLE: tappydevices
           INTERNAL_SECRET: !Ref InternalSecret
+          TELEGRAM_BOT_TOKEN: !Ref TelegramBotToken
+          TELEGRAM_CHAT_ID: !Ref TelegramChatId
       Events:
         Api:
           Type: Api
@@ -171,6 +182,8 @@ Resources:
           INTERNAL_SECRET: !Ref InternalSecret
           SPOTIFY_CLIENT_ID: !Ref SpotifyClientId
           SPOTIFY_CLIENT_SECRET: !Ref SpotifyClientSecret
+          TELEGRAM_BOT_TOKEN: !Ref TelegramBotToken
+          TELEGRAM_CHAT_ID: !Ref TelegramChatId
       Events:
         Api:
           Type: Api
@@ -201,6 +214,8 @@ Resources:
           INTERNAL_SECRET: !Ref InternalSecret
           SPOTIFY_CLIENT_ID: !Ref SpotifyClientId
           SPOTIFY_CLIENT_SECRET: !Ref SpotifyClientSecret
+          TELEGRAM_BOT_TOKEN: !Ref TelegramBotToken
+          TELEGRAM_CHAT_ID: !Ref TelegramChatId
       Events:
         Api:
           Type: Api


### PR DESCRIPTION
## What changed

Real-time Telegram pings for the interesting events, since with a handful of users a chat notification beats digging through CloudWatch:

- 👋 new user signed up / 🔑 user signed in (`registerUser`)
- 🎵 card added, with track and artist name (`addCard`)
- 📟 device claimed (`addDevice`)
- ❓ unknown card tapped on a device (`tapCard`) — the cue that a fresh card is waiting to be assigned in the dashboard

Each of the four Lambdas gets a small `notify()` helper (same copy-per-lambda pattern as `recordUserError`) that POSTs to the Telegram `sendMessage` API. It is strictly best-effort: try/catch around everything plus a 3-second `AbortSignal.timeout`, so a Telegram outage can never fail a sign-in or a tap.

Config plumbing follows the existing secret pattern: `TELEGRAM_BOT_TOKEN` (`NoEcho`) and `TELEGRAM_CHAT_ID` are SAM parameters fed from `.env` via `deploy.sh`, exposed as env vars only to the four functions that notify. Both default to empty, which turns notifications off entirely — deploys work fine before the bot exists. Bot setup steps are documented in the README.

## Reviewer notes

- Needs `./deploy.sh` after merge; nothing sensitive lands in code or git.
- Sign-in pings fire on *every* sign-in (new and returning users). Deliberately noisy to start; easy to mute the returning-user ping later if it gets old.
- Quick end-to-end test after deploy: tap an unregistered card — buzz on the device, ❓ ping in Telegram.
- Verified with `node --check` on all four handlers, `sam validate --lint`, and `bash -n deploy.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)